### PR TITLE
phase 2: migrate Shop and Profile to shared typography/spacing tokens

### DIFF
--- a/app/screens/main/ProfileDashboardScreen.tsx
+++ b/app/screens/main/ProfileDashboardScreen.tsx
@@ -20,6 +20,8 @@ import { FONTS } from '../../constants/fonts';
 import { supabase } from '../../lib/supabase';
 import { useTokenBalance } from '../../contexts/TokenContext';
 import { screenHeaderTheme, useTheme } from '../../contexts/ThemeContext';
+import { TYPOGRAPHY } from '../../constants/typography';
+import { SPACING } from '../../constants/spacing';
 
 // Profile Assets
 import VerifiedIcon from "../../../assets/ProfileAssets/Verified_Icon.svg";
@@ -418,7 +420,7 @@ const getStyles = (colors: any, theme: string) => StyleSheet.create({
     settingsButton: { height: 25, width: 44, borderRadius: 22, alignItems: 'center', justifyContent: 'center' },
     settingsIcon: { width: 24, height: 24 },
     scrollContent: { paddingBottom: 112 },
-    identityBlock: { paddingHorizontal: 24, paddingVertical: 20, borderBottomWidth: 1, borderBottomColor: colors.border },
+    identityBlock: { paddingHorizontal: SPACING.xxl, paddingVertical: SPACING.xl, borderBottomWidth: 1, borderBottomColor: colors.border },
     identityRow: { flexDirection: 'row', gap: 18 },
     avatarColumn: { alignItems: 'center', gap: 8 },
     avatarFrame: { width: 100, height: 100, borderRadius: 14, backgroundColor: colors.surface2, borderWidth: 2, borderColor: colors.border, overflow: 'hidden', position: 'relative', alignItems: 'center', justifyContent: 'center' },
@@ -429,16 +431,16 @@ const getStyles = (colors: any, theme: string) => StyleSheet.create({
     subtitle: { fontSize: 13, color: colors.textSecondary },
     bioText: { fontSize: 13, color: colors.textPrimary, fontWeight: '500' },
     editProfileText: { fontSize: 12, color: colors.favor },
-    badgesBlock: { paddingHorizontal: 24, paddingVertical: 20, gap: 16, borderBottomWidth: 1, borderBottomColor: colors.border },
+    badgesBlock: { paddingHorizontal: SPACING.xxl, paddingVertical: SPACING.xl, gap: SPACING.lg, borderBottomWidth: 1, borderBottomColor: colors.border },
     blockHeaderRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-    blockTitle: { fontSize: 12, fontFamily: FONTS.display, color: colors.textPrimary },
+    blockTitle: { ...TYPOGRAPHY.pixelHeading, color: colors.textPrimary },
     setLink: { flexDirection: 'row', alignItems: 'center', gap: 4 },
     setLinkText: { fontSize: 14, fontWeight: '400', color: colors.favor },
     badgeRow: { flexDirection: 'row', justifyContent: 'space-between', marginHorizontal: -4 },
     badgeSlot: { flex: 1, height: 104, borderRadius: 14, backgroundColor: colors.surface, alignItems: 'center', justifyContent: 'center', marginHorizontal: 4, paddingVertical: 12 },
     badgeImage: { width: 50, height: 50, marginBottom: 6 },
     badgeLabelText: { fontSize: 11, fontWeight: '600', color: colors.textSecondary, textAlign: 'center' },
-    reputationBlock: { paddingHorizontal: 24, paddingVertical: 20, gap: 14 },
+    reputationBlock: { paddingHorizontal: SPACING.xxl, paddingVertical: SPACING.xl, gap: 14 },
     rankChip: { paddingHorizontal: 10, paddingVertical: 4, borderRadius: 20, backgroundColor: 'rgba(0,245,255,0.08)', borderWidth: 1, borderColor: 'rgba(0,245,255,0.2)' },
     rankChipText: { fontSize: 12, fontWeight: '600', color: colors.favor },
     karmaLabelRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
@@ -458,7 +460,7 @@ const getStyles = (colors: any, theme: string) => StyleSheet.create({
     leaderboardLeft: { flexDirection: 'row', alignItems: 'center', gap: 10 },
     leaderboardIcon: { width: 24, height: 24, resizeMode: 'contain' },
     leaderboardTextCluster: { gap: 2 },
-    leaderboardTitle: { fontSize: 10, fontFamily: FONTS.display, color: colors.textPrimary },
+    leaderboardTitle: { ...TYPOGRAPHY.pixelLabel, color: colors.textPrimary },
     leaderboardSubtitle: { fontSize: 11, color: colors.textSecondary },
     leaderboardRight: { flexDirection: 'row', alignItems: 'center', gap: 4 },
     leaderboardCta: { fontSize: 13, fontWeight: '600', color: colors.token },
@@ -467,7 +469,7 @@ const getStyles = (colors: any, theme: string) => StyleSheet.create({
     tokenCard: { height: 64, paddingHorizontal: 16, borderRadius: 14, borderWidth: 1, borderColor: colors.token, backgroundColor: withOpacity(colors.token, 0.12), flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
     tokenLeftCluster: { flexDirection: 'row', alignItems: 'center', gap: 10 },
     tokenIcon: { width: 26, height: 26, resizeMode: 'contain' },
-    tokenTitle: { fontSize: 10, fontFamily: FONTS.display, color: colors.textPrimary },
+    tokenTitle: { ...TYPOGRAPHY.pixelLabel, color: colors.textPrimary },
     tokenSubtitle: { fontSize: 11, color: colors.textSecondary },
     tokenRightCluster: { flexDirection: 'row', alignItems: 'center', gap: 6 },
     tokenValue: { fontSize: 22, fontWeight: '700', color: colors.token },
@@ -477,6 +479,6 @@ const getStyles = (colors: any, theme: string) => StyleSheet.create({
     questCard: { height: 64, paddingHorizontal: 16, borderRadius: 14, borderWidth: 1, borderColor: colors.xp, backgroundColor: withOpacity(colors.xp, 0.12), flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
     questLeftCluster: { flexDirection: 'row', alignItems: 'center', gap: 10 },
     questIcon: { width: 26, height: 26, resizeMode: 'contain' },
-    questTitle: { fontSize: 10, fontFamily: FONTS.display, color: colors.textPrimary },
+    questTitle: { ...TYPOGRAPHY.pixelLabel, color: colors.textPrimary },
     questSubtitle: { fontSize: 11, color: colors.textSecondary },
 });

--- a/app/screens/main/Shop.tsx
+++ b/app/screens/main/Shop.tsx
@@ -15,7 +15,8 @@ import { useCustomAlert } from '../../contexts/AlertContext';
 import { supabase } from '../../lib/supabase';
 import appSoundManager, { AppSoundCategory } from '../../lib/SoundManager';
 import { screenHeaderTheme, useTheme } from '../../contexts/ThemeContext';
-import { FONTS } from '../../constants/fonts';
+import { TYPOGRAPHY } from '../../constants/typography';
+import { SPACING } from '../../constants/spacing';
 
 type ShopCategory = 'all' | 'clothing' | 'accessories' | 'face' | 'hairstyles' | 'backgrounds';
 
@@ -227,13 +228,13 @@ const getStyles = (colors: any, theme: string) => StyleSheet.create({
   title: { ...screenHeaderTheme.text.title, color: colors.textPrimary },
   balanceChip: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingVertical: 8, paddingHorizontal: 14, borderRadius: 20, borderWidth: 1, borderColor: 'rgba(255, 215, 0, 0.45)', backgroundColor: withOpacity(colors.token, 0.18) },
   balanceText: { fontSize: 15, fontFamily: 'SpaceMono-Bold', fontWeight: '700', color: colors.token },
-  previewCard: { flexDirection: 'row', alignItems: 'center', gap: 16, paddingHorizontal: 16, paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: colors.border, backgroundColor: colors.surface },
+  previewCard: { flexDirection: 'row', alignItems: 'center', gap: SPACING.lg, paddingHorizontal: SPACING.lg, paddingVertical: SPACING.md, borderBottomWidth: 1, borderBottomColor: colors.border, backgroundColor: colors.surface },
   avatarContainer: { width: 64, height: 64, backgroundColor: colors.surface2, borderRadius: 14, overflow: 'hidden', justifyContent: 'center', alignItems: 'center', position: 'relative', borderWidth: 1.5, borderColor: colors.border },
   layerAbsolute: { position: 'absolute', width: '100%', height: '100%' },
   customizeButton: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, paddingVertical: 7, paddingHorizontal: 14, borderRadius: 10, borderWidth: 1, borderColor: colors.border, backgroundColor: colors.surface2 },
   customizeButtonText: { fontSize: 13, fontFamily: 'DMSans-Medium', fontWeight: '500', color: colors.textPrimary },
   previewTextBlock: { flex: 1, flexDirection: 'column', alignItems: 'flex-start', justifyContent: 'center', gap: 2 },
-  previewTitle: { fontSize: 10, fontFamily: FONTS.display, color: colors.textPrimary },
+  previewTitle: { ...TYPOGRAPHY.pixelLabel, color: colors.textPrimary },
   previewEquipped: { fontSize: 12, fontFamily: 'DMSans-Regular', fontWeight: '400', color: colors.textSecondary },
   filterRow: { borderBottomWidth: 1, borderBottomColor: colors.border, backgroundColor: colors.bg },
   filterScroll: { flexGrow: 0 },


### PR DESCRIPTION
Shop: previewTitle uses TYPOGRAPHY.pixelLabel; previewCard gap and paddings use SPACING tokens. Removed now-unused FONTS import.

Profile: blockTitle uses TYPOGRAPHY.pixelHeading; leaderboardTitle, tokenTitle, questTitle use TYPOGRAPHY.pixelLabel. identityBlock, badgesBlock, reputationBlock paddings use SPACING.xxl/xl; badgesBlock gap uses SPACING.lg.

Skipped non-exact matches (karmaTitle fontSize 9, reputationBlock gap 14, DMSans-Bold/Medium text labels, H_PADDING-driven Shop paddings) to avoid forced fits per the migration rule.